### PR TITLE
Support HiddenValueDomainWhitelist

### DIFF
--- a/docs/resources/user_attribute.md
+++ b/docs/resources/user_attribute.md
@@ -34,6 +34,7 @@ resource "looker_user_attribute" "my_user_attribute" {
 ### Optional
 
 - `default_value` (String)
+- `hidden_value_domain_whitelist` (String)
 - `id` (String) The ID of this resource.
 - `user_can_edit` (Boolean)
 - `user_can_view` (Boolean)

--- a/pkg/looker/resource_user_attribute.go
+++ b/pkg/looker/resource_user_attribute.go
@@ -48,6 +48,11 @@ func resourceUserAttribute() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"hidden_value_domain_whitelist": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -61,15 +66,17 @@ func resourceUserAttributeCreate(ctx context.Context, d *schema.ResourceData, m 
 	userAttributeValueIsHidden := d.Get("value_is_hidden").(bool)
 	userAttributeUserCanView := d.Get("user_can_view").(bool)
 	userAttributeUserCanEdit := d.Get("user_can_edit").(bool)
+	userAttributeHiddenValueDomainWhitelist := d.Get("hidden_value_domain_whitelist").(string)
 
 	writeUserAttribute := apiclient.WriteUserAttribute{
-		Name:          userAttributeName,
-		Label:         userAttributeLabel,
-		Type:          userAttributeType,
-		DefaultValue:  &userAttributeDefaultValue,
-		ValueIsHidden: &userAttributeValueIsHidden,
-		UserCanView:   &userAttributeUserCanView,
-		UserCanEdit:   &userAttributeUserCanEdit,
+		Name:                       userAttributeName,
+		Label:                      userAttributeLabel,
+		Type:                       userAttributeType,
+		DefaultValue:               &userAttributeDefaultValue,
+		ValueIsHidden:              &userAttributeValueIsHidden,
+		UserCanView:                &userAttributeUserCanView,
+		UserCanEdit:                &userAttributeUserCanEdit,
+		HiddenValueDomainWhitelist: &userAttributeHiddenValueDomainWhitelist,
 	}
 
 	log.Printf("[DEBUG] Create user attribute %s", userAttributeName)
@@ -116,6 +123,9 @@ func resourceUserAttributeRead(ctx context.Context, d *schema.ResourceData, m in
 	if err = d.Set("user_can_edit", userAttribute.UserCanEdit); err != nil {
 		return diag.FromErr(err)
 	}
+	if err = d.Set("hidden_value_domain_whitelist", userAttribute.HiddenValueDomainWhitelist); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }
@@ -132,15 +142,17 @@ func resourceUserAttributeUpdate(ctx context.Context, d *schema.ResourceData, m 
 	userAttributeValueIsHidden := d.Get("value_is_hidden").(bool)
 	userAttributeUserCanView := d.Get("user_can_view").(bool)
 	userAttributeUserCanEdit := d.Get("user_can_edit").(bool)
+	userAttributeHiddenValueDomainWhitelist := d.Get("hidden_value_domain_whitelist").(string)
 
 	writeUserAttribute := apiclient.WriteUserAttribute{
-		Name:          userAttributeName,
-		Label:         userAttributeLabel,
-		Type:          userAttributeType,
-		DefaultValue:  &userAttributeDefaultValue,
-		ValueIsHidden: &userAttributeValueIsHidden,
-		UserCanView:   &userAttributeUserCanView,
-		UserCanEdit:   &userAttributeUserCanEdit,
+		Name:                       userAttributeName,
+		Label:                      userAttributeLabel,
+		Type:                       userAttributeType,
+		DefaultValue:               &userAttributeDefaultValue,
+		ValueIsHidden:              &userAttributeValueIsHidden,
+		UserCanView:                &userAttributeUserCanView,
+		UserCanEdit:                &userAttributeUserCanEdit,
+		HiddenValueDomainWhitelist: &userAttributeHiddenValueDomainWhitelist,
 	}
 
 	log.Printf("[DEBUG] Update user attribute %s", userAttributeID)


### PR DESCRIPTION
If you want to build a parameterized connection off a user attribute that is a hidden value, you need to be able to set hidden_value_domain_whitelist.

I have kept the same type as the go sdk - a string. It however supports a comma delimited string with many domains.