### PR TITLE
Add ADC option for connections with Looker (Google Cloud Core) 

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -77,9 +77,9 @@ resource "looker_connection" "snowflake_connection" {
 - `ssl` (Boolean)
 - `tmp_db_name` (String)
 - `tunnel_id` (String)
-- `uses_application_default_credentials` (Boolean)
 - `user_attribute_fields` (Set of String)
 - `user_db_credentials` (Boolean)
+- `uses_application_default_credentials` (Boolean)
 - `verify_ssl` (Boolean)
 
 ### Read-Only

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -59,6 +59,7 @@ resource "looker_connection" "snowflake_connection" {
 - `db_timezone` (String)
 - `disable_context_comment` (Boolean)
 - `file_type` (String) Certificate key file type (.json or .p12).
+- `impersonated_service_account` (String)
 - `jdbc_additional_params` (String)
 - `maintenance_cron` (String)
 - `max_billing_gigabytes` (String)
@@ -76,6 +77,7 @@ resource "looker_connection" "snowflake_connection" {
 - `ssl` (Boolean)
 - `tmp_db_name` (String)
 - `tunnel_id` (String)
+- `uses_application_default_credentials` (Boolean)
 - `user_attribute_fields` (Set of String)
 - `user_db_credentials` (Boolean)
 - `verify_ssl` (Boolean)

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,9 @@ toolchain go1.23.5
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.13.0
-	github.com/looker-open-source/sdk-codegen/go v0.0.2-0.20220425180701-d51a6750f7d5
+	github.com/looker-open-source/sdk-codegen/go v0.24.20
 	github.com/stretchr/testify v1.8.2
 )
-
-replace github.com/looker-open-source/sdk-codegen/go => github.com/hirosassa/sdk-codegen/go v0.0.2-0.20220604105615-6ef4a4149ee4
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,6 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/hirosassa/sdk-codegen/go v0.0.2-0.20220604105615-6ef4a4149ee4 h1:hbD0dlYBTJJZafX48Vm1JsvueNgiQ5w9By4OPydGCZU=
-github.com/hirosassa/sdk-codegen/go v0.0.2-0.20220604105615-6ef4a4149ee4/go.mod h1:YM/IYSsTPk7I54j4l6PduNJYgXyOShuaMi7mD6xic8E=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -295,6 +293,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/looker-open-source/sdk-codegen/go v0.24.20 h1:jhCvuiiKdagwE8mxL3tQtStHv2AJr/zJTJNzaXT5cpU=
+github.com/looker-open-source/sdk-codegen/go v0.24.20/go.mod h1:YM/IYSsTPk7I54j4l6PduNJYgXyOShuaMi7mD6xic8E=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/pkg/looker/resource_connection.go
+++ b/pkg/looker/resource_connection.go
@@ -231,6 +231,14 @@ func resourceConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"uses_application_default_credentials": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"impersonated_service_account": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -415,6 +423,15 @@ func expandWriteDBConnection(d *schema.ResourceData) (*apiclient.WriteDBConnecti
 		oauthApplicationId := v.(string) // for api breaking change
 		writeDBConnection.OauthApplicationId = &oauthApplicationId
 	}
+	if v, ok := d.GetOk("uses_application_default_credentials"); ok {
+		usesApplicationDefaultCredentials := v.(bool)
+		writeDBConnection.UsesApplicationDefaultCredentials = &usesApplicationDefaultCredentials
+	}
+	if v, ok := d.GetOk("impersonated_service_account"); ok {
+		impersonatedServiceAccount := v.(string)
+		writeDBConnection.ImpersonatedServiceAccount = &impersonatedServiceAccount
+	}
+
 
 	userAttributeFields := expandStringListFromSet(d.Get("user_attribute_fields").(*schema.Set))
 	writeDBConnection.UserAttributeFields = &userAttributeFields
@@ -576,6 +593,12 @@ func flattenConnection(connection apiclient.DBConnection, d *schema.ResourceData
 		return err
 	}
 	if err := d.Set("oauth_application_id", connection.OauthApplicationId); err != nil {
+		return err
+	}
+	if err := d.Set("uses_application_default_credentials", connection.UsesApplicationDefaultCredentials); err != nil {
+		return err
+	}
+	if err := d.Set("impersonated_service_account", connection.ImpersonatedServiceAccount); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/looker/resource_connection.go
+++ b/pkg/looker/resource_connection.go
@@ -439,37 +439,48 @@ func expandWriteDBConnection(d *schema.ResourceData) (*apiclient.WriteDBConnecti
 	if _, ok := d.GetOk("pdt_context_override"); ok {
 		var pdtContextOverride apiclient.WriteDBConnectionOverride
 		if v, ok := d.GetOk("pdt_context_override.0.context"); ok {
-			pdtContextOverride.Context = v.(*string)
+			context := v.(string)
+			pdtContextOverride.Context = &context
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.host"); ok {
-			pdtContextOverride.Host = v.(*string)
+			host := v.(string)
+			pdtContextOverride.Host = &host
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.port"); ok {
-			pdtContextOverride.Port = v.(*string)
+			port := v.(string)
+			pdtContextOverride.Port = &port
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.username"); ok {
-			pdtContextOverride.Username = v.(*string)
+			username := v.(string)
+			pdtContextOverride.Username = &username
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.password"); ok {
-			pdtContextOverride.Password = v.(*string)
+			password := v.(string)
+			pdtContextOverride.Password = &password
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.certificate"); ok {
-			pdtContextOverride.Certificate = v.(*string)
+			certificate := v.(string)
+			pdtContextOverride.Certificate = &certificate
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.file_type"); ok {
-			pdtContextOverride.FileType = v.(*string)
+			fileType := v.(string)
+			pdtContextOverride.FileType = &fileType
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.database"); ok {
-			pdtContextOverride.Database = v.(*string)
+			database := v.(string)
+			pdtContextOverride.Database = &database
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.schema"); ok {
-			pdtContextOverride.Schema = v.(*string)
+			schema := v.(string)
+	        pdtContextOverride.Schema = &schema
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.jdbc_additional_params"); ok {
-			pdtContextOverride.JdbcAdditionalParams = v.(*string)
+			jdbcAdditionalParams := v.(string)
+        	pdtContextOverride.JdbcAdditionalParams = &jdbcAdditionalParams
 		}
 		if v, ok := d.GetOk("pdt_context_override.0.after_connect_statements"); ok {
-			pdtContextOverride.AfterConnectStatements = v.(*string)
+			afterConnectStatements := v.(string)
+        	pdtContextOverride.AfterConnectStatements = &afterConnectStatements
 		}
 
 		writeDBConnection.PdtContextOverride = &pdtContextOverride

--- a/pkg/looker/resource_connection.go
+++ b/pkg/looker/resource_connection.go
@@ -374,9 +374,15 @@ func expandWriteDBConnection(d *schema.ResourceData) (*apiclient.WriteDBConnecti
 		verifySsl := v.(bool)
 		writeDBConnection.VerifySsl = &verifySsl
 	}
-	if v, ok := d.GetOk("tmp_db_name"); ok {
-		tmpDbName := v.(string)
-		writeDBConnection.TmpDbName = &tmpDbName
+	if d.HasChange("tmp_db_name") {
+		old, new := d.GetChange("tmp_db_name")
+		if new == nil && old != nil {
+			tmpDbName := ""
+			writeDBConnection.TmpDbName = &tmpDbName
+		} else if new != nil {
+			tmpDbName := new.(string)
+			writeDBConnection.TmpDbName = &tmpDbName
+		}
 	}
 	if v, ok := d.GetOk("jdbc_additional_params"); ok {
 		jdbcAdditionalParams := v.(string)
@@ -419,17 +425,35 @@ func expandWriteDBConnection(d *schema.ResourceData) (*apiclient.WriteDBConnecti
 		disable_context_comment := v.(bool)
 		writeDBConnection.DisableContextComment = &disable_context_comment
 	}
-	if v, ok := d.GetOk("oauth_application_id"); ok {
-		oauthApplicationId := v.(string) // for api breaking change
-		writeDBConnection.OauthApplicationId = &oauthApplicationId
+	if d.HasChange("oauth_application_id") {
+		old, new := d.GetChange("oauth_application_id")
+		if new == nil && old != nil {
+			oauthApplicationId := ""
+			writeDBConnection.OauthApplicationId = &oauthApplicationId
+		} else if new != nil {
+			oauthApplicationId := new.(string)
+			writeDBConnection.OauthApplicationId = &oauthApplicationId
+		}
 	}
-	if v, ok := d.GetOk("uses_application_default_credentials"); ok {
-		usesApplicationDefaultCredentials := v.(bool)
-		writeDBConnection.UsesApplicationDefaultCredentials = &usesApplicationDefaultCredentials
+	if d.HasChange("uses_application_default_credentials") {
+		old, new := d.GetChange("uses_application_default_credentials")
+		if new == nil && old != nil {
+			usesApplicationDefaultCredentials := false
+			writeDBConnection.UsesApplicationDefaultCredentials = &usesApplicationDefaultCredentials
+		} else if new != nil {
+			usesApplicationDefaultCredentials := new.(bool)
+			writeDBConnection.UsesApplicationDefaultCredentials = &usesApplicationDefaultCredentials
+		}
 	}
-	if v, ok := d.GetOk("impersonated_service_account"); ok {
-		impersonatedServiceAccount := v.(string)
-		writeDBConnection.ImpersonatedServiceAccount = &impersonatedServiceAccount
+	if d.HasChange("impersonated_service_account") {
+		old, new := d.GetChange("impersonated_service_account")
+		if new == nil && old != nil {
+			impersonatedServiceAccount := ""
+			writeDBConnection.ImpersonatedServiceAccount = &impersonatedServiceAccount
+		} else if new != nil {
+			impersonatedServiceAccount := new.(string)
+			writeDBConnection.ImpersonatedServiceAccount = &impersonatedServiceAccount
+		}
 	}
 
 


### PR DESCRIPTION
Added an Application Default Credentials[1] parameter that works with Google Cloud Core.
- [x] Google Cloud Core ADC is not supported by the currently referenced SDK version, update the version.
- [x] Added process to delete previous information when connection authentication method is changed.
- [x] Update `connection.md`
- [x] Fixed problem with`pdt_context_override` not working
- [x] test
  - [x] run check-docs

[1] https://cloud.google.com/looker/docs/looker-core-dialects?hl=ja#adc-with-bigquery