### PR TITLE
do not update group list if the member group list is not changed

### DIFF
--- a/pkg/looker/resource_group_membership.go
+++ b/pkg/looker/resource_group_membership.go
@@ -118,23 +118,6 @@ func getGroupIDs(m interface{}, groupId string) ([]string, error) {
 	return flattenGroupIDs(groups), nil
 }
 
-func differentStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return true
-	}
-	counts := make(map[string]int)
-	for _, item := range a {
-		counts[item]++
-	}
-	for _, item := range b {
-		counts[item]--
-		if counts[item] < 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	targetGroupID := d.Id()
 

--- a/pkg/looker/util.go
+++ b/pkg/looker/util.go
@@ -61,3 +61,20 @@ func hash(val interface{}) string {
 	sha := sha256.Sum256([]byte(val.(string)))
 	return hex.EncodeToString(sha[:])
 }
+
+func differentStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return true
+	}
+	counts := make(map[string]int)
+	for _, item := range a {
+		counts[item]++
+	}
+	for _, item := range b {
+		counts[item]--
+		if counts[item] < 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/looker/util_test.go
+++ b/pkg/looker/util_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDifferentStringSlices(t *testing.T) {
+	tests := map[string]struct {
+		a       []string
+		b       []string
+		wantRes bool
+	}{
+		"same slice": {
+			a:       []string{"a", "b", "c"},
+			b:       []string{"a", "b", "c"},
+			wantRes: false,
+		},
+		"different slice": {
+			a:       []string{"a", "b", "c"},
+			b:       []string{"a", "b", "d"},
+			wantRes: true,
+		},
+		"one slice is empty": {
+			a:       []string{},
+			b:       []string{"a", "b", "c"},
+			wantRes: true,
+		},
+	}
+
+	for key, tt := range tests {
+		t.Run(key, func(t *testing.T) {
+			actual := differentStringSlices(tt.a, tt.b)
+			assert.Equal(t, tt.wantRes, actual)
+		})
+	}
+}
+
 func TestBuildTwoPartID(t *testing.T) {
 	tests := map[string]struct {
 		a       string


### PR DESCRIPTION
There is a bug on looker : when we update an existing group which contains groups, it removes a group authorization from a folder.

With this PR, we will update the group's group only if it changed, avoiding this issue most of the time.